### PR TITLE
feat(docker): improve development workflow with comprehensive Docker setup

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -88,7 +88,7 @@ Only proceed after user approval of the plan.
 Verify the implementation works in a realistic environment.
 
 #### For Web Features (Next.js):
-1. Start the dev server if needed: `npm run dev --filter=@fightrise/web`
+1. Start the dev server if needed: `npm run dev -- --filter=@fightrise/web`
 2. Use Playwright MCP to verify:
    ```
    mcp__playwright__browser_navigate to http://localhost:3000/<route>

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm run build
 
       - name: Run Discord API smoke tests
-        run: npm run test:smoke --filter=@fightrise/bot
+        run: npm run test:smoke -- --filter=@fightrise/bot
         env:
           SMOKE_DISCORD_TOKEN: ${{ secrets.SMOKE_DISCORD_TOKEN }}
           SMOKE_DISCORD_GUILD_ID: ${{ secrets.SMOKE_DISCORD_GUILD_ID }}
@@ -108,7 +108,7 @@ jobs:
         run: npm run build
 
       - name: Run Start.gg API smoke tests
-        run: npm run test:smoke --filter=@fightrise/startgg-client
+        run: npm run test:smoke -- --filter=@fightrise/startgg-client
         env:
           SMOKE_STARTGG_API_KEY: ${{ secrets.SMOKE_STARTGG_API_KEY }}
           SMOKE_STARTGG_TOURNAMENT_SLUG: ${{ vars.SMOKE_STARTGG_TOURNAMENT_SLUG }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ packages/database/prisma/*.db
 # Misc
 *.tsbuildinfo
 .eslintcache
+
+# Docker (user-specific configs)
+docker/cloudflared-config.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ FightRise is a Discord bot and web portal for running Start.gg fighting game tou
 ```bash
 # Development
 npm run dev                    # Run all apps/packages in dev mode (turbo)
-npm run dev --filter=@fightrise/bot   # Run just the bot
-npm run dev --filter=@fightrise/web   # Run just the web app
+npm run dev -- --filter=@fightrise/bot   # Run just the bot
+npm run dev -- --filter=@fightrise/web   # Run just the web app
 
 # Build & Start
 npm run build                  # Build all packages
@@ -31,11 +31,21 @@ npm run test:e2e               # Run Playwright browser E2E tests
 npm run test:smoke             # Run smoke tests against real APIs
 npm run lint                   # Run ESLint
 
-# Docker (for local Postgres & Redis only)
-docker compose -f docker/docker-compose.yml up -d postgres redis
+# Docker Development (recommended)
+npm run docker:dev          # Full stack with hot-reload
+npm run docker:dev:tunnel   # With Cloudflare Tunnel for OAuth
+npm run docker:dev:tools    # With pgAdmin and Redis Commander
+npm run docker:dev:all      # Everything
+npm run docker:down         # Stop all services
+npm run docker:infra        # Just Postgres and Redis
 
-# Docker Development (full stack with hot-reload - recommended)
-docker compose -f docker/docker-compose.dev.yml up
+# Docker commands (run in containers)
+npm run docker:db:generate  # Generate Prisma client
+npm run docker:db:push      # Push schema to database
+npm run docker:db:migrate   # Run migrations
+npm run docker:deploy       # Deploy Discord commands
+npm run docker:exec:web -- <cmd>  # Run any command in web container
+npm run docker:exec:bot -- <cmd>  # Run any command in bot container
 
 # Cloudflare Tunnel (for OAuth development)
 npm run tunnel                 # Exposes localhost:3000 for OAuth callbacks
@@ -219,7 +229,7 @@ Use the multi-layered test suite based on what you're building:
    const interaction = await client.executeCommand('mycommand', { option: 'value' });
    expect(interaction.lastReply?.content).toBe('Expected response');
    ```
-2. Run: `npm run test:integration --filter=@fightrise/bot`
+2. Run: `npm run test:integration -- --filter=@fightrise/bot`
 
 **For Database Changes:**
 1. Verify migrations work: `npm run db:push`

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "dotenv -e ../../.env -- tsx watch src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
-    "deploy": "tsx src/deploy-commands.ts",
+    "start": "dotenv -e ../../.env -- node dist/index.js",
+    "deploy": "dotenv -e ../../.env -- tsx src/deploy-commands.ts",
     "lint": "eslint --ext .ts,.js src/",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -22,7 +22,6 @@
     "@fightrise/startgg-client": "*",
     "bullmq": "^5.0.0",
     "discord.js": "^14.14.0",
-    "dotenv": "^16.3.0",
     "ioredis": "^5.3.0"
   },
   "devDependencies": {
@@ -30,6 +29,7 @@
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
     "@typescript-eslint/parser": "^8.53.1",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^8.55.0",
     "tsx": "^4.6.0",
     "typescript": "^5.3.0",

--- a/apps/bot/src/deploy-commands.ts
+++ b/apps/bot/src/deploy-commands.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { REST, Routes } from 'discord.js';
 import { loadCommands, getCommandsData } from './utils/commandLoader.js';
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { Client, Collection, GatewayIntentBits } from 'discord.js';
 import { loadCommands } from './utils/commandLoader.js';
 import { loadEvents } from './utils/eventLoader.js';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "dotenv -e ../../.env -- next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "dotenv -e ../../.env -- next start",
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -20,16 +20,17 @@
     "next-auth": "^4.24.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^5.3.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^8.55.0",
     "eslint-config-next": "^14.0.0",
-    "vitest": "^1.0.0",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@vitejs/plugin-react": "^4.2.0",
-    "jsdom": "^23.0.0"
+    "jsdom": "^23.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -18,8 +18,8 @@ COPY packages/database/prisma ./packages/database/prisma
 RUN npm run db:generate --workspace=@fightrise/database
 
 # Source code will be mounted as volume
-EXPOSE 3000
-ENV PORT=3000
+EXPOSE 4000
+ENV PORT=4000
 ENV HOSTNAME="0.0.0.0"
 
 CMD ["npm", "run", "dev", "--workspace=@fightrise/web"]

--- a/docker/cloudflared-config.yml.example
+++ b/docker/cloudflared-config.yml.example
@@ -1,0 +1,18 @@
+# Cloudflare Tunnel configuration for Docker development
+# Copy this to ~/.cloudflared/config-docker.yml and update with your values
+#
+# Prerequisites:
+# 1. Run: cloudflared tunnel login
+# 2. Run: cloudflared tunnel create fightrise-dev
+# 3. Copy this file: cp docker/cloudflared-config.yml.example ~/.cloudflared/config-docker.yml
+# 4. Update the values below with your tunnel UUID and domain
+
+tunnel: <TUNNEL-UUID>
+credentials-file: /home/nonroot/.cloudflared/<TUNNEL-UUID>.json
+
+ingress:
+  # Route to Next.js web app (Docker service name)
+  - hostname: fightrise-dev.yourdomain.com
+    service: http://web:4000
+  # Catch-all (required)
+  - service: http_status:404

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,14 +1,30 @@
 # Development Docker Compose configuration
 # Usage: docker compose -f docker/docker-compose.dev.yml up
 #
-# This extends the base configuration with:
-# - Development Dockerfile stages (hot-reload enabled)
-# - Source code volume mounts for live editing
-# - Anonymous volumes to preserve container node_modules
+# This provides a complete local development environment with:
+# - PostgreSQL database
+# - Redis for job queues
+# - Discord bot with hot-reload
+# - Next.js web app with hot-reload
+# - Cloudflare Tunnel for OAuth development (optional)
+#
+# Prerequisites:
+# - Copy .env.example to .env and configure credentials
+# - For tunnel: run `cloudflared tunnel login` and create tunnel first
+#   See docs/TUNNEL_SETUP.md for details
+#
+# Profiles:
+# - Default (no profile): postgres, redis, bot, web
+# - With tunnel: docker compose -f docker/docker-compose.dev.yml --profile tunnel up
 
 services:
+  # ===================
+  # Infrastructure
+  # ===================
+
   postgres:
     image: postgres:15-alpine
+    container_name: fightrise-postgres
     environment:
       POSTGRES_USER: fightrise
       POSTGRES_PASSWORD: ${DB_PASSWORD:-devpassword}
@@ -25,6 +41,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    container_name: fightrise-redis
     ports:
       - "6379:6379"
     volumes:
@@ -35,11 +52,16 @@ services:
       timeout: 5s
       retries: 5
 
+  # ===================
+  # Applications
+  # ===================
+
   bot:
     build:
       context: ..
       dockerfile: docker/Dockerfile.bot
       target: dev
+    container_name: fightrise-bot
     environment:
       DATABASE_URL: postgresql://fightrise:${DB_PASSWORD:-devpassword}@postgres:5432/fightrise
       REDIS_URL: redis://redis:6379
@@ -72,19 +94,22 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.web
       target: dev
+    container_name: fightrise-web
     environment:
       DATABASE_URL: postgresql://fightrise:${DB_PASSWORD:-devpassword}@postgres:5432/fightrise
-      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:4000}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-dev-secret-change-in-production}
       DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
       DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+      PORT: 4000
     ports:
-      - "3000:3000"
+      - "4000:4000"
     volumes:
       # Mount source code for hot-reload
       - ../apps/web/src:/app/apps/web/src:ro
       - ../apps/web/app:/app/apps/web/app:ro
       - ../apps/web/public:/app/apps/web/public:ro
+      - ../apps/web/components:/app/apps/web/components:ro
       - ../packages/shared/src:/app/packages/shared/src:ro
       - ../packages/ui/src:/app/packages/ui/src:ro
       - ../packages/database/src:/app/packages/database/src:ro
@@ -96,12 +121,71 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
 
+  # ===================
+  # Development Tools
+  # ===================
+
+  # Cloudflare Tunnel for OAuth development
+  # Requires prior setup:
+  #   1. cloudflared tunnel login
+  #   2. cloudflared tunnel create fightrise-dev
+  #   3. cp docker/cloudflared-config.yml.example docker/cloudflared-config.yml
+  #   4. Edit docker/cloudflared-config.yml with your tunnel UUID and domain
+  # See docs/TUNNEL_SETUP.md for details
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    container_name: fightrise-tunnel
+    profiles:
+      - tunnel
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      # Mount tunnel credentials from home directory
+      - ${HOME}/.cloudflared:/home/nonroot/.cloudflared:ro
+      # Mount docker-specific config from project
+      - ./cloudflared-config.yml:/etc/cloudflared/config.yml:ro
+    depends_on:
+      - web
+    restart: unless-stopped
+
+  # Database admin UI (optional)
+  # Access at http://localhost:5050
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: fightrise-pgadmin
+    profiles:
+      - tools
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@fightrise.local}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+    ports:
+      - "5050:80"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    depends_on:
+      - postgres
+
+  # Redis admin UI (optional)
+  # Access at http://localhost:8081
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    container_name: fightrise-redis-commander
+    profiles:
+      - tools
+    environment:
+      REDIS_HOSTS: local:redis:6379
+    ports:
+      - "8081:8081"
+    depends_on:
+      - redis
+
 volumes:
   postgres_data:
   redis_data:
+  pgadmin_data:

--- a/docs/DISCORD_SETUP.md
+++ b/docs/DISCORD_SETUP.md
@@ -339,7 +339,7 @@ For production deployments, use a dedicated secrets manager instead of `.env` fi
 ### Bot Not Responding to Commands
 
 1. **Check the bot is online** - Look for green status indicator
-2. **Verify commands are deployed** - Run `npm run deploy --filter=@fightrise/bot`
+2. **Verify commands are deployed** - Run `npm run deploy -- --filter=@fightrise/bot`
 3. **Check bot has permissions** - Ensure bot role has required permissions in the channel
 4. **Check intents are enabled** - Verify privileged intents in Developer Portal
 
@@ -373,7 +373,7 @@ Now that Discord is configured:
 - [ ] Complete [Start.gg Setup](./STARTGG_SETUP.md) if you haven't already
 - [ ] Run `npm install` at the repository root
 - [ ] Copy `.env.example` to `.env` and add your credentials
-- [ ] Run `npm run dev --filter=@fightrise/bot` to start the bot
+- [ ] Run `npm run dev -- --filter=@fightrise/bot` to start the bot
 - [ ] Invite the bot to your test server using the generated URL
 - [ ] Test with `/tournament setup` command
 

--- a/docs/STARTGG_SETUP.md
+++ b/docs/STARTGG_SETUP.md
@@ -321,7 +321,7 @@ Expected response:
 Run the smoke tests:
 
 ```bash
-npm run test:smoke --filter=@fightrise/startgg-client
+npm run test:smoke -- --filter=@fightrise/startgg-client
 ```
 
 ### API Explorer
@@ -510,7 +510,7 @@ Now that Start.gg is configured:
 - [ ] Complete [Discord Setup](./DISCORD_SETUP.md) if you haven't already
 - [ ] Run `npm install` at the repository root
 - [ ] Copy `.env.example` to `.env` and add your credentials
-- [ ] Run `npm run test:smoke --filter=@fightrise/startgg-client` to verify API access
+- [ ] Run `npm run test:smoke -- --filter=@fightrise/startgg-client` to verify API access
 - [ ] Run `npm run dev` to start the full application
 
 See [Implementation Status](./IMPLEMENTATION_STATUS.md) to track progress or find ways to contribute.

--- a/docs/TUNNEL_SETUP.md
+++ b/docs/TUNNEL_SETUP.md
@@ -179,6 +179,43 @@ STARTGG_REDIRECT_URI="https://fightrise-dev.yourdomain.com/api/auth/callback/sta
 
 ## Development Workflow
 
+### Option A: Full Docker Stack with Tunnel (Recommended)
+
+Run everything in Docker with a single command:
+
+```bash
+npm run docker:dev:tunnel
+```
+
+This starts PostgreSQL, Redis, bot, web, and the Cloudflare Tunnel together.
+
+**Prerequisites for Docker tunnel:**
+1. Complete the tunnel setup above (steps 1-5)
+2. Create Docker-specific config:
+   ```bash
+   cp docker/cloudflared-config.yml.example docker/cloudflared-config.yml
+   ```
+3. Edit `docker/cloudflared-config.yml` with your tunnel UUID and domain
+4. Important: Change `service: http://localhost:3000` to `service: http://web:3000` (Docker networking)
+
+### Option B: Local Tunnel + Docker Infrastructure
+
+If you prefer running the tunnel locally:
+
+**Terminal 1:** Start the tunnel
+```bash
+npm run tunnel
+```
+
+**Terminal 2:** Start infrastructure and apps
+```bash
+npm run docker:dev
+```
+
+### Option C: Local Tunnel + Local Apps
+
+For maximum control:
+
 **Terminal 1:** Start the tunnel
 ```bash
 npm run tunnel
@@ -186,13 +223,15 @@ npm run tunnel
 
 **Terminal 2:** Start infrastructure
 ```bash
-docker compose -f docker/docker-compose.yml up -d postgres redis
+npm run docker:infra
 ```
 
 **Terminal 3:** Start the web app
 ```bash
-npm run dev --filter=@fightrise/web
+npm run dev -- --filter=@fightrise/web
 ```
+
+---
 
 Now visit `https://fightrise-dev.yourdomain.com` and OAuth flows will work.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@fightrise/startgg-client": "*",
         "bullmq": "^5.0.0",
         "discord.js": "^14.14.0",
-        "dotenv": "^16.3.0",
         "ioredis": "^5.3.0"
       },
       "devDependencies": {
@@ -38,6 +37,7 @@
         "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "^8.53.1",
         "@typescript-eslint/parser": "^8.53.1",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^8.55.0",
         "tsx": "^4.6.0",
         "typescript": "^5.3.0",
@@ -63,6 +63,7 @@
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.0",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^8.55.0",
         "eslint-config-next": "^14.0.0",
         "jsdom": "^23.0.0",
@@ -5195,6 +5196,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,21 @@
     "db:push": "turbo db:push",
     "db:migrate": "turbo db:migrate",
     "tunnel": "cloudflared tunnel run fightrise-dev",
-    "clean": "turbo clean && rm -rf node_modules"
+    "clean": "turbo clean && rm -rf node_modules",
+    "docker:dev": "docker compose --env-file .env -f docker/docker-compose.dev.yml up",
+    "docker:dev:build": "docker compose --env-file .env -f docker/docker-compose.dev.yml up --build",
+    "docker:dev:tunnel": "docker compose --env-file .env -f docker/docker-compose.dev.yml --profile tunnel up",
+    "docker:dev:tools": "docker compose --env-file .env -f docker/docker-compose.dev.yml --profile tools up",
+    "docker:dev:all": "docker compose --env-file .env -f docker/docker-compose.dev.yml --profile tunnel --profile tools up",
+    "docker:down": "docker compose --env-file .env -f docker/docker-compose.dev.yml --profile tunnel --profile tools down",
+    "docker:infra": "docker compose --env-file .env -f docker/docker-compose.dev.yml up -d postgres redis",
+    "docker:exec:web": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec web",
+    "docker:exec:bot": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec bot",
+    "docker:run": "docker compose --env-file .env -f docker/docker-compose.dev.yml run --rm web",
+    "docker:db:generate": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec web npm run db:generate",
+    "docker:db:push": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec web npm run db:push",
+    "docker:db:migrate": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec web npm run db:migrate",
+    "docker:deploy": "docker compose --env-file .env -f docker/docker-compose.dev.yml exec bot npm run deploy"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
     // Run directly in apps/web to avoid turbo trying to start all packages
     command: process.env.CI
       ? 'npm run start --prefix apps/web'
-      : 'npm run dev --filter=@fightrise/web',
+      : 'npm run dev -- --filter=@fightrise/web',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000, // 2 minutes for Next.js to start


### PR DESCRIPTION
## Summary

- Fix npm script argument passing for turbo filters
- Add proper environment variable loading from root `.env` file
- Enhance Docker development setup with tunnel, admin tools, and better ergonomics

## Changes

### npm Script Fixes
- All `--filter` flags now use `--` separator (e.g., `npm run dev -- --filter=@fightrise/bot`)
- Updated all documentation to reflect correct syntax

### Environment Loading
- Added `dotenv-cli` to bot and web apps
- Bot/web scripts now use `dotenv -e ../../.env --` to load root `.env`
- Removed inline `import 'dotenv/config'` from bot source files
- Docker scripts use `--env-file .env` flag

### Docker Compose Enhancements
- Added Cloudflare Tunnel service (`tunnel` profile) for OAuth development
- Added pgAdmin (`tools` profile) at `localhost:5050`
- Added Redis Commander (`tools` profile) at `localhost:8081`
- Web service now runs on port 4000 (avoids conflicts with local dev)
- Added explicit container names for easier management

### New npm Scripts
| Script | Description |
|--------|-------------|
| `npm run docker:dev` | Full stack with hot-reload |
| `npm run docker:dev:tunnel` | With Cloudflare Tunnel |
| `npm run docker:dev:tools` | With pgAdmin & Redis Commander |
| `npm run docker:dev:all` | Everything |
| `npm run docker:down` | Stop all services |
| `npm run docker:db:generate` | Run db:generate in container |
| `npm run docker:db:push` | Run db:push in container |
| `npm run docker:deploy` | Deploy Discord commands in container |
| `npm run docker:exec:web` | Run command in web container |
| `npm run docker:exec:bot` | Run command in bot container |

## Testing

- [x] Verified `npm run dev -- --filter=@fightrise/web` runs only web app
- [x] Verified `npm run dev -- --filter=@fightrise/bot` loads env and connects to Discord
- [x] Validated docker-compose.dev.yml with all profiles
- [x] Tested `--env-file .env` removes variable warnings

🤖 Generated with [Claude Code](https://claude.ai/code)